### PR TITLE
Update Cake.MinVer to target Cake v4.0.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "4.0.0",
+      "version": "3.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
     name: ${{ matrix.job.os }}
     runs-on: ${{ matrix.job.os }}
     steps:
+      - name: Setup net8.0
+        uses: actions/setup-dotnet@v4.0.1
+        with:
+          dotnet-version: "8.0.303"
       - name: Setup net6.0
         uses: actions/setup-dotnet@v4.0.1
         with:

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "allowPrerelease": false,
-    "version": "7.0.100",
+    "version": "8.0.303",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Cake.MinVer/Cake.MinVer.csproj
+++ b/src/Cake.MinVer/Cake.MinVer.csproj
@@ -40,8 +40,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="3.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Common" Version="3.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
 
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Cake.MinVer/Cake.MinVer.csproj
+++ b/src/Cake.MinVer/Cake.MinVer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <RootNamespace>Cake.MinVer</RootNamespace>
 
     <AssemblyName>Cake.MinVer</AssemblyName>

--- a/test/Cake.MinVer.Tests/Cake.MinVer.Tests.csproj
+++ b/test/Cake.MinVer.Tests/Cake.MinVer.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="3.0.0" />
-    <PackageReference Include="Cake.Common" Version="3.0.0" />
-    <PackageReference Include="Cake.Testing" Version="3.0.0" />
+    <PackageReference Include="Cake.Core" Version="4.0.0" />
+    <PackageReference Include="Cake.Common" Version="4.0.0" />
+    <PackageReference Include="Cake.Testing" Version="4.0.0" />
 
     <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
 


### PR DESCRIPTION
Fixes #71 
Updated this to use Cake tool version 4 to get rid of the warning

```
The assembly 'Cake.MinVer, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null'
is referencing an older version of Cake.Core (3.0.0).
For best compatibility it should target Cake.Core version 4.0.0.
```

Once built, it needs to update its own tools, since it is referencing itself in version 3 and also cake.args at version 3. Cake.args have not been updated to 4.


